### PR TITLE
[codex] Pin Node runtime to 20.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "typescript": "^6.0.3"
       },
       "engines": {
-        "node": ">=20.9.0"
+        "node": "20.x"
       }
     },
     "node_modules/@azure/msal-common": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=20.9.0"
+    "node": "20.x"
   },
   "scripts": {
     "dev": "cross-env NEXT_TURBOPACK=0 next dev",


### PR DESCRIPTION
## Summary

Pins the project Node runtime to `20.x` instead of the open-ended `>=20.9.0` range.

## Why

Vercel warns that `>=20.9.0` overrides the Project Settings value of `20.x` and allows the deployment to automatically move to Node 24.x. Keeping `20.x` matches the stable runtime already configured for the project and avoids surprise major-version upgrades.

## Validation

- `npm.cmd run lint`
- `npm.cmd run typecheck`
- `npm.cmd run build`