### PR TITLE
[codex] Remove Netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,0 @@
-[build.environment]
-  NODE_VERSION = "20.11.1"


### PR DESCRIPTION
## Summary

Removes the Netlify-specific build configuration because the project is hosted on Vercel.

## Details

- Deleted `netlify.toml`.
- Kept Vercel-compatible runtime controls (`engines.node` / `.nvmrc`) untouched so deployments continue to use Node 20.
- Verified no Netlify references remain in the repository.

## Validation

- `rg -n "netlify|Netlify|@netlify|NODE_VERSION" .` returns no matches.
- `npm.cmd run lint`
- `npm.cmd run typecheck`
- `npm.cmd run build`