### PR TITLE
feat(news, articles): показывать дату публикации

### DIFF
--- a/services/articles.service.ts
+++ b/services/articles.service.ts
@@ -15,6 +15,7 @@ export interface Article {
   };
   slug: string;
   excerpt: string;
+  createdAt?: string;
   updatedAt?: string;
   seo?: SeoFields | null;
   content: {
@@ -46,6 +47,7 @@ export const ArticlesService = {
           }
           slug
           excerpt
+          createdAt
           updatedAt
           seo {
             noIndex
@@ -76,6 +78,7 @@ export const ArticlesService = {
           }
           slug
           excerpt
+          createdAt
           updatedAt
           seo {
             metaTitle

--- a/src/app/[locale]/articles/[slug]/page.module.scss
+++ b/src/app/[locale]/articles/[slug]/page.module.scss
@@ -10,4 +10,12 @@
     line-height: 1.2;
     overflow-wrap: anywhere;
   }
+  .publishDate {
+    margin-top: clamp(-10px, -1.4vw, -6px);
+    display: block;
+    text-align: center;
+    color: $primaryColor;
+    font-size: clamp(14px, 1.6vw, 16px);
+    line-height: 1.2;
+  }
 }

--- a/src/app/[locale]/articles/[slug]/page.tsx
+++ b/src/app/[locale]/articles/[slug]/page.tsx
@@ -17,6 +17,7 @@ import {
   optimizedOgImagePath,
 } from "@/lib/seo";
 import { TheJsonLd } from "@/components/JsonLd/TheJsonLd";
+import { formatPublicationDate } from "@/lib/format-date";
 
 type Props = {
   params: Promise<{ slug: string; locale: string }>;
@@ -102,6 +103,11 @@ export default async function ArticlePage({ params }: Props) {
       <div className="container">
         <div className={s.content}>
           <h1 className={s.title}>{article.title}</h1>
+          {article.createdAt && (
+            <time className={s.publishDate} dateTime={article.createdAt}>
+              {formatPublicationDate(article.createdAt, locale)}
+            </time>
+          )}
           <ThePageContent content={article.content.raw.children} />
         </div>
       </div>

--- a/src/app/[locale]/articles/page.tsx
+++ b/src/app/[locale]/articles/page.tsx
@@ -27,7 +27,7 @@ export default async function Articles() {
       />
       <TheHero title1={t("heroTitle")} url1="articles" />
       <div className="container">
-        <TheArticlesList articles={articles} linkLabel={t("link")} />
+        <TheArticlesList articles={articles} linkLabel={t("link")} locale={locale} />
       </div>
       <TheFeedback />
     </>

--- a/src/app/[locale]/news/[slug]/page.module.scss
+++ b/src/app/[locale]/news/[slug]/page.module.scss
@@ -10,6 +10,14 @@
     line-height: 1.2;
     overflow-wrap: anywhere;
   }
+  .publishDate {
+    margin-top: -12px;
+    display: block;
+    text-align: center;
+    color: $primaryColor;
+    font-size: clamp(14px, 1.6vw, 16px);
+    line-height: 1.2;
+  }
 }
 .newsPage {
   display: grid;
@@ -49,6 +57,12 @@
       margin-bottom: 20px;
       text-align: center;
     }
+  }
+  .date {
+    margin-bottom: 4px;
+    color: $primaryColor;
+    font-size: 13px;
+    line-height: 1.2;
   }
   .list {
     display: grid;

--- a/src/app/[locale]/news/[slug]/page.tsx
+++ b/src/app/[locale]/news/[slug]/page.tsx
@@ -21,6 +21,7 @@ import { TheJsonLd } from "@/components/JsonLd/TheJsonLd";
 import { TheNewsViewTracker } from "@/components/NewsViewTracker/TheNewsViewTracker";
 import { ThePopularNews } from "@/components/PopularNewsComponent/ThePopularNews";
 import { getPopularNews, getPopularNewsLabels } from "@/lib/popular-news";
+import { formatPublicationDate } from "@/lib/format-date";
 
 type Props = {
   params: Promise<{ locale: Locale; slug: string }>;
@@ -114,6 +115,11 @@ export default async function NewsPage({ params }: Props) {
           <div className={s.newsPage}>
             <div className={s.content}>
               <h1 className={s.title}>{news.title}</h1>
+              {news.date && (
+                <time className={s.publishDate} dateTime={news.date}>
+                  {formatPublicationDate(news.date, locale)}
+                </time>
+              )}
               <ThePageContent content={news.description.raw.children} />
             </div>
             <div className={s.separator}></div>
@@ -125,7 +131,11 @@ export default async function NewsPage({ params }: Props) {
                     <li key={id}>
                       <Link className={s.link} href={`/${locale}/news/${slug}`}>
                         <div className={s.titleBlock}>
-                          <p className={s.date}>{date}</p>
+                          {date && (
+                            <p className={s.date}>
+                              {formatPublicationDate(date, locale)}
+                            </p>
+                          )}
                           <h3>{title}</h3>
                           {/* <p className={s.description}>{excerpt}</p> */}
                         </div>

--- a/src/app/[locale]/news/page.tsx
+++ b/src/app/[locale]/news/page.tsx
@@ -72,7 +72,7 @@ export default async function News({ searchParams }: NewsPageProps) {
       />
       <TheHero title1={t("heroTitle")} url1="news" />
       <div className="container">
-        <TheNewsList news={news} linkLabel={t("link")} />
+        <TheNewsList news={news} linkLabel={t("link")} locale={locale} />
         <ThePaginationControls
           totalPages={totalPages}
           currentPage={currentPage}

--- a/src/components/ArticlesList/TheArticlesList.module.scss
+++ b/src/components/ArticlesList/TheArticlesList.module.scss
@@ -66,6 +66,13 @@
   padding: clamp(16px, 2vw, 20px);
 }
 
+.date {
+  margin-bottom: 8px;
+  color: $primaryColor;
+  font-size: clamp(13px, 1.4vw, 14px);
+  line-height: 1.2;
+}
+
 .title {
   margin: 0 0 8px;
   color: $blackColor;

--- a/src/components/ArticlesList/TheArticlesList.tsx
+++ b/src/components/ArticlesList/TheArticlesList.tsx
@@ -4,20 +4,23 @@ import { TheClampedText } from "../ClampedText/TheClampedText";
 import { Link } from "@/i18n/navigation";
 import Image from "next/image";
 import type { Locale } from "next-intl";
+import { formatPublicationDate } from "@/lib/format-date";
 
 type TheArticlesListProps = ArticlesResponse & {
   linkLabel: string;
+  locale?: Locale;
   contentLocale?: Locale;
 };
 
 export const TheArticlesList = ({
   articles,
   linkLabel,
+  locale,
   contentLocale,
 }: TheArticlesListProps) => {
   return (
     <div className={s.articlesList}>
-      {articles.map(({ id, cover, title, excerpt, slug }: Article) => (
+      {articles.map(({ id, cover, title, excerpt, slug, createdAt }: Article) => (
         <article key={id} className={s.card}>
           <Link
             className={s.mediaLink}
@@ -35,8 +38,13 @@ export const TheArticlesList = ({
           </Link>
 
           <div className={s.content}>
+            {createdAt && (
+              <time className={s.date} dateTime={createdAt}>
+                {formatPublicationDate(createdAt, locale ?? contentLocale)}
+              </time>
+            )}
             <h3 className={s.title}>{title}</h3>
-            <TheClampedText className={s.excerpt} lines={4}>
+            <TheClampedText className={s.excerpt} lines={3}>
               {excerpt}
             </TheClampedText>
           </div>

--- a/src/components/LastNewsComponent/TheLastNews.tsx
+++ b/src/components/LastNewsComponent/TheLastNews.tsx
@@ -37,7 +37,12 @@ export async function TheLastNews() {
           </svg>
         </Link>
       </div>
-      <TheNewsList news={news} linkLabel={t("link")} contentLocale={contentLocale} />
+      <TheNewsList
+        news={news}
+        linkLabel={t("link")}
+        locale={locale as Locale}
+        contentLocale={contentLocale}
+      />
     </TheMotionWrapper>
   );
 }

--- a/src/components/NewsListComponent/TheNewsList.tsx
+++ b/src/components/NewsListComponent/TheNewsList.tsx
@@ -4,14 +4,21 @@ import { TheClampedText } from "../ClampedText/TheClampedText";
 import { Link } from "@/i18n/navigation";
 import Image from "next/image";
 import type { Locale } from "next-intl";
+import { formatPublicationDate } from "@/lib/format-date";
 
 interface NewsProps {
   news: NewResponse[];
   linkLabel: string;
+  locale?: Locale;
   contentLocale?: Locale;
 }
 
-export const TheNewsList = ({ news, linkLabel, contentLocale }: NewsProps) => {
+export const TheNewsList = ({
+  news,
+  linkLabel,
+  locale,
+  contentLocale,
+}: NewsProps) => {
   return (
     <div className={s.newsList}>
       {news.map(({ id, cover, date, title, excerpt, slug }: NewResponse) => (
@@ -32,7 +39,11 @@ export const TheNewsList = ({ news, linkLabel, contentLocale }: NewsProps) => {
           </Link>
 
           <div className={s.content}>
-            <time className={s.date}>{date}</time>
+            {date && (
+              <time className={s.date} dateTime={date}>
+                {formatPublicationDate(date, locale ?? contentLocale)}
+              </time>
+            )}
             <h3 className={s.title}>{title}</h3>
             <TheClampedText className={s.excerpt} lines={3}>
               {excerpt}

--- a/src/components/PopularNewsComponent/ThePopularNews.tsx
+++ b/src/components/PopularNewsComponent/ThePopularNews.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import { TrendingUp } from "lucide-react";
 import { Link } from "@/i18n/navigation";
 import type { PopularNewsItem } from "@/lib/popular-news";
+import { formatPublicationDate } from "@/lib/format-date";
 import s from "./ThePopularNews.module.scss";
 
 type PopularNewsLabels = {
@@ -55,9 +56,11 @@ export function ThePopularNews({ news, labels, locale }: PopularNewsProps) {
             </div>
 
             <div className={s.body}>
-              <div className={s.meta}>
-                <span>{item.date}</span>
-              </div>
+              {item.date && (
+                <div className={s.meta}>
+                  <span>{formatPublicationDate(item.date, locale)}</span>
+                </div>
+              )}
               <h3 className={s.cardTitle}>{item.title}</h3>
               <p className={s.excerpt}>{item.excerpt}</p>
             </div>

--- a/src/lib/format-date.ts
+++ b/src/lib/format-date.ts
@@ -1,0 +1,47 @@
+// Uzbek month names in the nominative case — next-intl locale "uz" is not
+// backed by a full ICU dataset here, so we format that locale by hand
+// (mirrors the approach in TendersList / plants pages).
+const UZ_MONTHS = [
+  "yanvar",
+  "fevral",
+  "mart",
+  "aprel",
+  "may",
+  "iyun",
+  "iyul",
+  "avgust",
+  "sentyabr",
+  "oktyabr",
+  "noyabr",
+  "dekabr",
+];
+
+// Formats a CMS date/datetime string (ISO from Hygraph — `date`, `createdAt`,
+// `updatedAt`, …) as a localized publication date. Falls back to the trimmed
+// raw value when it cannot be parsed, so nothing ever renders as "Invalid Date".
+export function formatPublicationDate(
+  raw?: string | null,
+  locale?: string,
+): string {
+  if (!raw) return "";
+
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) return raw.trim();
+
+  const safeLocale = locale ?? "en";
+
+  if (safeLocale.startsWith("uz")) {
+    return `${date.getUTCDate()}-${UZ_MONTHS[date.getUTCMonth()]}, ${date.getUTCFullYear()}-yil`;
+  }
+
+  try {
+    return new Intl.DateTimeFormat(safeLocale, {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+      timeZone: "UTC",
+    }).format(date);
+  } catch {
+    return raw.trim();
+  }
+}


### PR DESCRIPTION
## Что и зачем

В новостях и статьях не отображалась дата публикации. Добавил её в стиле самого сайта (фирменный зелёный `#12903e`, шрифт Sofia Sans, существующие карточки и отступы).

## Изменения

**Новый общий форматтер даты** — `src/lib/format-date.ts`
- Локализует дату через `Intl.DateTimeFormat` для ru/en; узбекский форматируется вручную по названиям месяцев (тот же подход, что уже применён на страницах тендеров и станций).
- При неразборчивой дате аккуратно возвращает исходную строку — «Invalid Date» никогда не рендерится.

**Новости**
- На странице новости (`/news/[slug]`) дата публикации теперь выводится под заголовком — по центру, фирменным зелёным. Раньше даты на этой странице не было.
- В карточках списка, в сайдбаре «Последние новости» и в блоке «Популярные новости» дата теперь форматируется по языку, а не выводится «сырой» строкой из CMS (например, `2026-08-12`).

**Статьи**
- Сервис запрашивает системное поле Hygraph `createdAt` (у модели статьи нет собственного поля даты).
- Дата публикации показывается на странице статьи (`/articles/[slug]`) под заголовком и в карточках списка статей.

## Детали

- Все даты обёрнуты в `<time datetime="…">` — семантично и полезно для SEO.
- Формат учитывает язык интерфейса (ru / en / uz).
- В карточках статей клэмп текста уменьшен с 4 до 3 строк, чтобы новая строка с датой не ломала фиксированную высоту карточки (как в карточках новостей).

## Проверки

- `eslint` по всем затронутым файлам — без замечаний.
- `tsc` — в изменённых файлах ошибок нет (оставшиеся ошибки типизации — предсуществующие, про импорты изображений из `public/`, к этим правкам не относятся).

## На заметку

Для статей дата берётся из `createdAt`, т.к. у модели `Article` в Hygraph нет отдельного поля даты. Если нужно, чтобы редакторы задавали дату вручную (как у новостей), можно добавить поле `date` в модель `Article` и переключиться на него.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAFtS2PnEZGmnHATrHQw54)_